### PR TITLE
Implement `Rolling Year` for dashboard and user activity list default views

### DIFF
--- a/app/controllers/dashboard.js
+++ b/app/controllers/dashboard.js
@@ -36,6 +36,23 @@
         return deferred.promise;
     };
 
+    $scope.getCurrentDate = function () {
+        return new Date();
+    };
+
+    $scope.getDateOneYearAgo = function () {
+        var date = new Date();
+        date.setDate(date.getDate() - 365);
+        return date;
+    };
+
+    $scope.rollingYear = function () {
+        $scope.period_start = $scope.getDateOneYearAgo();
+        $scope.period_end = $scope.getCurrentDate();
+
+        $scope.getUserActivity();
+    };
+
     $scope.thisYear = function () {
         var now = new Date();
         var year = now.getFullYear();
@@ -149,7 +166,7 @@
     };
 
     init();
-    $scope.thisYear();
+    $scope.rollingYear();
 
 }]);
 

--- a/app/controllers/user-activity/user-activity-list.js
+++ b/app/controllers/user-activity/user-activity-list.js
@@ -147,13 +147,20 @@
         return deferred.promise;
     };
 
-    $scope.rollingYear = function () {
-        var now = new Date();
-        var yearAgo = now;
-        yearAgo.setDate(now.getDate() - 365);
+    $scope.getCurrentDate = function () {
+        return new Date();
+    };
 
-        $scope.period_end = now;
-        $scope.period_start = yearAgo;
+    $scope.getDateOneYearAgo = function () {
+        var date = new Date();
+        date.setDate(date.getDate() - 365);
+        return date;
+    };
+
+    $scope.rollingYear = function () {
+        $scope.period_start = $scope.getDateOneYearAgo();
+        $scope.period_end = $scope.getCurrentDate();
+        $scope.getUserActivity();
     };
 
     init = function () {

--- a/app/views/dashboard.html
+++ b/app/views/dashboard.html
@@ -39,6 +39,7 @@
 
     <div class="row">
         <div class="col">
+            <button type="button" class="btn btn-sm btn-light" ng-click="rollingYear()">Rolling Year</button>
             <button type="button" class="btn btn-sm btn-light" ng-click="thisYear()">This Year</button>
             <button type="button" class="btn btn-sm btn-light" ng-click="thisMonth()">This Month</button>
             <button type="button" class="btn btn-sm btn-light" ng-click="lastYear()">Last Year</button>


### PR DESCRIPTION
Resolves #36 

This PR correctly implements `Rolling Year` for the default tab and time period for the `Dashboard` (public view) and `User Activity List` (admin view).

<img width="577" alt="image" src="https://github.com/DNNCommunity/Dnn.CommunityMetrics/assets/4568451/1fb8d219-db85-448f-9fe0-8671e3d58485">

**NOTE:** Screenshot reflects local development environment (which is using the old site theme.